### PR TITLE
hotfix gestion carte

### DIFF
--- a/creation_carte/utils_carte.php
+++ b/creation_carte/utils_carte.php
@@ -35,10 +35,15 @@ if(isset($_SESSION["id_perso"])){
 			$terrain_choix = $_SESSION['terrain_choix'] = $_POST['liste_terrain'];
 		}
 
-		if(isset($_POST['choix_carte']) || isset($_SESSION['choix_carte'])){
+		if(isset($_GET['id']) || isset($_SESSION['choix_carte'])){
 			
-			if (isset($_POST['choix_carte'])) {
-				$carte = $_SESSION['choix_carte'] = $_POST['choix_carte'];
+			if (isset($_GET['id'])) {
+				if($_GET['id']==1){
+					$map = 'carte';
+				}else{
+					$map = 'carte'.$_GET['id'];
+				}
+				$carte = $_SESSION['choix_carte'] = $map;
 			}
 			else {
 				$carte = $_SESSION['choix_carte'];
@@ -171,34 +176,26 @@ if(isset($_SESSION["id_perso"])){
 				</div>
 			</div>
 			
-			<form method="post" action="utils_carte.php">
-				<u>Choix de la carte à modifier :</u><br>
-				<select name="choix_carte" onchange="this.form.submit()">
-					<OPTION value="carte" <?php if( isset($_SESSION['choix_carte']) && $_SESSION['choix_carte'] == "carte") { echo "selected"; } ?>>carte de jeu</option>
-					<OPTION value="carte2" <?php if( isset($_SESSION['choix_carte']) && $_SESSION['choix_carte'] == "carte2") { echo "selected"; } ?>>carte de jeu 2</option>
-					<OPTION value="carte3" <?php if( isset($_SESSION['choix_carte']) && $_SESSION['choix_carte'] == "carte3") { echo "selected"; } ?>>carte de jeu 3</option>
-				</select>
-				<input type="submit" name="eval_choix_carte" value="ok" class='btn btn-primary'>
-			</form>
-			
 			<?php
 			if (!isset($X_MAXD) && !isset($Y_MAXD)) {
-				echo "<h3>Création de la carte</h3>";
-				echo "<form method='post' action='utils_carte.php'>";
-				echo "	<div class='form-row'>";
-				echo "		<div class='form-group col-md-4'>";
-				echo "			<label for='creation_x_max'>X Max carte : </label>";
-				echo "			<input type='text' name='creation_x_max' id='creation_x_max' value=''>";
-				echo "		</div>";
-				echo "		<div class='form-group col-md-4'>";
-				echo "			<label for='creation_y_max'>Y Max carte : </label>";
-				echo "			<input type='text' name='creation_y_max' id='creation_y_max' value=''>";
-				echo "		</div>";
-				echo "		<div class='form-group col-md-4'>";
-				echo "			<input type='submit' class='btn btn-primary' value='Créer la carte'>";
-				echo "		</div>";
-				echo "	</div>";
-				echo "</form>";
+			?>
+				<h3>Création de la carte</h3>
+				<form method='post' action='utils_carte.php'>
+					<div class='form-row'>
+						<div class='form-group col-md-4'>
+							<label for='creation_x_max'>X Max carte : </label>
+							<input type='text' name='creation_x_max' id='creation_x_max' value=''>
+						</div>
+						<div class='form-group col-md-4'>
+							<label for='creation_y_max'>Y Max carte : </label>
+							<input type='text' name='creation_y_max' id='creation_y_max' value=''>
+						</div>
+						<div class='form-group col-md-4'>
+							<input type='submit' class='btn btn-primary' value='Créer la carte'>
+						</div>
+					</div>
+				</form>
+			<?php
 			}			
 			?>
 

--- a/mvc/controller/mapController.php
+++ b/mvc/controller/mapController.php
@@ -1,7 +1,7 @@
 <?php
 require_once("../mvc/model/Map.php");
 require_once("../mvc/model/Administration.php");
-require_once('controller.php');
+require_once("controller.php");
 require_once("../app/validator/formValidator.php");
 
 class MapController extends Controller
@@ -304,13 +304,20 @@ class MapController extends Controller
      */
     public function destroy($id)
     {
-		$map = new Map();
-		$result = $map->destroy($id);
+		$admin = new Administration();
+		$dispo = $admin->getMaintenanceMode();
 		
-		if($result){
-			$_SESSION['flash'] = ["class"=>"success","message"=>"La carte n°$id a été supprimée"];
+		if($id==1 && $dispo['valeur_config']==1){
+			$_SESSION['flash'] = ["class"=>"danger","message"=>"Attention ! La carte n°$id ne peut pas être supprimée si le jeu n'est pas en maintenance"];
 		}else{
-			$_SESSION['flash'] = ["class" => "warning","message"=>"Une erreur inconnue est survenue, veuillez recommencer. Si le problème persiste, contactez l'administrateur."];
+			$map = new Map();
+			$result = $map->destroy($id);
+			
+			if($result){
+				$_SESSION['flash'] = ["class"=>"success","message"=>"La carte n°$id a été supprimée"];
+			}else{
+				$_SESSION['flash'] = ["class" => "warning","message"=>"Une erreur inconnue est survenue, veuillez recommencer. Si le problème persiste, contactez l'administrateur."];
+			}
 		}
 		
 		header('location:?');

--- a/mvc/model/Map.php
+++ b/mvc/model/Map.php
@@ -29,7 +29,7 @@ class Map extends Model
 		8=>['eau',92,191,207],
 		9=>['eau_profonde',39,141,227]
 	];
-	protected $mapTables = ['CARTE' => 1,'CARTE2' => 2,'CARTE3' => 3];// à refactoriser
+	protected $mapTables = ['carte' => 1,'carte2' => 2,'carte3' => 3];// à refactoriser
 
 	public function __set($name, $value) {}
 	
@@ -313,49 +313,51 @@ class Map extends Model
 		$db = $this->dbConnectPDO();
 		$map = array_search($id,$this->mapTables);
 		
-		// Vider table histo_stats_camp_pv (après affichage sur forum)
-		$query = "DELETE FROM histo_stats_camp_pv";
-		$db->query($query);
-		
-		// Vider table perso_in_batiment
-		$query = "DELETE FROM perso_in_batiment";
-		$db->query($query);
-		
-		// Vider table perso_in_train
-		$query = "DELETE FROM perso_in_train";
-		$db->query($query);
-		
-		// Vider table instance_batiment_canon
-		$query = "DELETE FROM instance_batiment_canon";
-		$db->query($query);
+		if($map=='carte'){
+			// Vider table histo_stats_camp_pv (après affichage sur forum)
+			$query = "DELETE FROM histo_stats_camp_pv";
+			$db->query($query);
+			
+			// Vider table perso_in_batiment
+			$query = "DELETE FROM perso_in_batiment";
+			$db->query($query);
+			
+			// Vider table perso_in_train
+			$query = "DELETE FROM perso_in_train";
+			$db->query($query);
+			
+			// Vider table instance_batiment_canon
+			$query = "DELETE FROM instance_batiment_canon";
+			$db->query($query);
 
-		// Vider table instance_batiment
-		$query = "DELETE FROM instance_batiment";
-		$db->query($query);
-		
-		// Vider table pnj_in_zone (à redéfinir après installation carte)
-		$query = "DELETE FROM pnj_in_zone";
-		$db->query($query);
-		
-		// Vider table instance_pnj
-		$query = "DELETE FROM instance_pnj";
-		$db->query($query);
-		
-		// Vider table zones (à redéfinir après installation carte)
-		$query = "DELETE FROM zones";
-		$db->query($query);
-		
-		// Vider table liaisons_gare
-		$query = "DELETE FROM liaisons_gare";
-		$db->query($query);
-		
-		// Vider table objet_in_carte
-		$query = "DELETE FROM objet_in_carte";
-		$db->query($query);
-		
-		// Vider table perso_as_respawn
-		$query = "DELETE FROM perso_as_respawn";
-		$db->query($query);
+			// Vider table instance_batiment
+			$query = "DELETE FROM instance_batiment";
+			$db->query($query);
+			
+			// Vider table pnj_in_zone (à redéfinir après installation carte)
+			$query = "DELETE FROM pnj_in_zone";
+			$db->query($query);
+			
+			// Vider table instance_pnj
+			$query = "DELETE FROM instance_pnj";
+			$db->query($query);
+			
+			// Vider table zones (à redéfinir après installation carte)
+			$query = "DELETE FROM zones";
+			$db->query($query);
+			
+			// Vider table liaisons_gare
+			$query = "DELETE FROM liaisons_gare";
+			$db->query($query);
+			
+			// Vider table objet_in_carte
+			$query = "DELETE FROM objet_in_carte";
+			$db->query($query);
+			
+			// Vider table perso_as_respawn
+			$query = "DELETE FROM perso_as_respawn";
+			$db->query($query);
+		}
 		
 		// réinitialiser la table Carte
 		$query = "TRUNCATE TABLE $map";

--- a/mvc/view/map/index.php
+++ b/mvc/view/map/index.php
@@ -52,7 +52,8 @@ ob_start();
 						<div class='me-4'>carte n°<?= $id ?></div>
 						<!--<img class='me-4' src="" width="34" height="34" alt='miniature carte n°{{$id}}'>-->
 						<a href='../creation_carte/utils_carte.php?id=<?= $id ?>' class='mx-3 btn btn-primary'>Editer</a>
-						<?php if($id==1 && $dispo==1): ?>
+
+						<?php if($id==1 && $dispo['valeur_config']==1): ?>
 							<button class='btn btn-danger' disabled>Supprimer</button>
 							<small class='mt-2'>vous devez mettre le jeu en maintenance pour supprimer la carte principale.<br>Attention, toute suppression de la carte n°1 réinitialise le jeu (sauf les persos)</small>
 						<?php else: ?>


### PR DESCRIPTION
- Modification de la casse des noms des tables "carte' car système Linux sensible à la casse pour SQL.
- Modification de la variable $dispo liée à un changement de fonctionnalité
- Protections contre la suppression non désirée de la carte principale
- Pas de suppression des instances (bat, pnj, etc.) si ce n'est pas la carte principale
- Suppression du choix de changement de carte dans l'édition de carte (zone à refactoriser)